### PR TITLE
Renforcement de la fiabilité des regex, auparavant trop restrictifs

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -7,9 +7,10 @@ from pywikibot import page
 WIKTIONNAIRE = pywikibot.Site('fr', 'wiktionary')
 WIKIPEDIA = pywikibot.Site('fr','wikipedia')
 WIKIDATA = pywikibot.Site('wikidata', 'wikidata')
-source = re.compile("{{source\|[\w|\{\{| |\}|é|.|&]+")
-wAuthor = re.compile("{{w\|[\w| ]+}}")
-link = re.compile("\[\[[\w| ]+\]\]")
+source = re.compile("{{source\|.+}}")
+wAuthor = re.compile("{{w\|[^|}]+[|}]")
+nomWAuthor = re.compile("{{nom w pc\|([^|}]+)\|([^|}]+)[|}]")
+link = re.compile("\[\[[^|\]]+\]\]")
 gender = "P21"
 nationality ="P27"
 birthDate = "P569"
@@ -35,6 +36,7 @@ def sources(word):
         for template in templates:
             #Authors are linked to wikipedia
             wikiAuthors = [x[4:len(x)-2] for x in wAuthor.findall(template)]
+            wikiAuthors += [x[0]+x[1] for x in nomWAuthor.findall(template)]
             for wikiAuthor in wikiAuthors:
                 if wikiAuthor not in cache[authors]:
                     cache[authors][wikiAuthor] = characteristics(wikiAuthor)


### PR DESCRIPTION
- traitement du É et de tous pleins d'autres caractères dans les noms d'auteur (ex : {{w|Émile Zola}} n'était pas reconnu)
- gestion de {{nom w pc}}, à la mode ces temps-ci